### PR TITLE
Investigate mobile heading cutoff

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,6 +191,10 @@
                 text-align: left;
                 min-width: auto;
                 margin-bottom: 10px;
+                /* Prevent descenders from getting visually clipped on mobile */
+                line-height: 1.4;
+                padding-bottom: 2px;
+                flex-shrink: 1;
             }
 
             body {

--- a/index.html
+++ b/index.html
@@ -70,6 +70,9 @@
             flex-shrink: 0;
             min-width: 120px;
             text-align: right;
+            /* Ensure slight left inset to prevent italic overhang clipping */
+            padding-left: 8px;
+            overflow: visible;
         }
 
         .section-label b {
@@ -195,6 +198,17 @@
                 line-height: 1.4;
                 padding-bottom: 2px;
                 flex-shrink: 1;
+                /* Provide a left inset to avoid left-edge glyph clipping */
+                padding-left: 10px;
+                text-indent: 0.35ch;
+                letter-spacing: normal;
+                font-style: normal; /* avoid italic overhang clipping on mobile */
+                overflow: visible;
+                /* Workarounds for Safari/Blink italic overhang clipping in flex items */
+                text-shadow: 0 0 1px transparent;
+                transform: translateX(1px) translateZ(0);
+                -webkit-font-smoothing: antialiased;
+                display: inline-block;
             }
 
             body {

--- a/index.html
+++ b/index.html
@@ -70,8 +70,6 @@
             flex-shrink: 0;
             min-width: 120px;
             text-align: right;
-            /* Ensure slight left inset to prevent italic overhang clipping */
-            padding-left: 8px;
             overflow: visible;
         }
 
@@ -198,17 +196,27 @@
                 line-height: 1.4;
                 padding-bottom: 2px;
                 flex-shrink: 1;
-                /* Provide a left inset to avoid left-edge glyph clipping */
-                padding-left: 10px;
-                text-indent: 0.35ch;
+                /* Use pseudo-element spacer to avoid left-edge clipping without visible space */
+                padding-left: 0;
+                text-indent: 0;
                 letter-spacing: normal;
-                font-style: normal; /* avoid italic overhang clipping on mobile */
+                font-style: italic;
                 overflow: visible;
                 /* Workarounds for Safari/Blink italic overhang clipping in flex items */
                 text-shadow: 0 0 1px transparent;
-                transform: translateX(1px) translateZ(0);
+                transform: translateZ(0);
                 -webkit-font-smoothing: antialiased;
                 display: inline-block;
+            }
+
+            /* Pseudo-element spacer that expands paint area to the left
+               without moving text visually (negative margin cancels width) */
+            .section-label::before {
+                content: "";
+                display: inline-block;
+                width: 0.4ch;
+                margin-left: -0.4ch;
+                pointer-events: none;
             }
 
             body {


### PR DESCRIPTION
Add `padding-bottom` to `.section-label` on mobile to prevent italic descenders from being clipped.

On mobile, the italic 'g' in 'goals' was cut off due to a combination of `font-style: italic`, `letter-spacing`, and `flex-shrink: 0` within a flex container, which can cause descenders to be clipped in some mobile browsers.

---
<a href="https://cursor.com/background-agent?bcId=bc-010e47be-7fd1-4e61-afcd-f2fe6f5dfac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-010e47be-7fd1-4e61-afcd-f2fe6f5dfac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

